### PR TITLE
[PR] Add `new` keyword to docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Fill a bug report to help improve the project's stability
+title: "[[BUG] Your issue"
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happened instead.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Environnement (please complete the following information):**
+ - OS: [e.g. Ubuntu 18.04]
+ - Browser [e.g. chrome, safari]
+ - Module version [e.g. lotuslang@1.2.3]
+ - Node version [with `node -v`]
+
+**Notes and Misc**
+Add any other note or additional information here.

--- a/.github/ISSUE_TEMPLATE/error-or-typo-report.md
+++ b/.github/ISSUE_TEMPLATE/error-or-typo-report.md
@@ -1,0 +1,17 @@
+---
+name: Error or typo report
+about: Help us spot errors in our code or repo
+title: "[TYPO]"
+labels: error/typo
+assignees: ''
+
+---
+
+**Describe the error**
+A clear and concise description of what the error is.
+
+**Area**
+Is it an error in the code ? in the test suite ? in the github repo ? etc...
+
+**Exact location**
+Where exactly is the error (a link would be apreciated) ? (e.g. in the src/app.js file, from line 30 to line 35)

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an idea or a feature for the project
+title: "[FEATURE]"
+labels: enhancement
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+If you've found or opened other issues related to this feature, please link them in your description.
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/docs/Internal/Lexical Structure.md
+++ b/docs/Internal/Lexical Structure.md
@@ -6,6 +6,22 @@ For more user- and beginner-friendly informations, as well as more in-depth expl
 
 If you're a developers wanting to implement a tokenizer/lexer for Lotus, you might want to see [Lexer Algorithms]() for more machine-friendly definitions.
 
+
+
+## Preface : definitions
+
+This section defines some of the technical words used in this document. Some of those are context-specific. In such a case, multiple definitions will be given and the context will be noted in *italics*.
+
+
+
+**Comment** : Text that is ignored by the interpreter
+
+**Condition** : 
+
+**Keyword** : Word that has a special meaning to the interpreter, and as such, can't be used as a variable identifier, class identifier, interface identifier, function identifier, or method identifier
+
+
+
 ## Comments
 
 Comments are one or multiple lines of text ignored by the interpreter. See [Comments]() for more information.

--- a/docs/Internal/Lexical Structure.md
+++ b/docs/Internal/Lexical Structure.md
@@ -211,7 +211,6 @@ while (!isNotFinished) {
             someString
         }
     }
-    
 ```
 
 <div>

--- a/docs/Internal/Lexical Structure.md
+++ b/docs/Internal/Lexical Structure.md
@@ -493,6 +493,59 @@ lightCycle.printInfo()
 <p>This is a Light cycle from Syd Mead</p>
 </div>
 
+### new keyword
+
+The `new` keyword is used to create a new instance of a class or interface. It has the following format
+
+- the `new` keyword : create a new instance of the specified class or interface
+
+- an `identifier` : this is the name of the class or interface you want to instantiate
+
+*Example usage :*
+
+`logger.lts` | File defining the `Logger` class
+
+```ruby
+namespace Utils.Logging
+
+import System.Text
+
+class Logger {
+    strBuilder = default(StringBuilder)
+    logInConsole = true;
+    
+    Logger(name, inConsole = true) {
+        strBuilder = new StringBuilder("Started logging for " + name)
+        logInConsole = inConsole
+    }
+
+    def append(text) {
+        strBuilder.appendLine(text)
+    }
+        
+    def log() {
+        if (logInConsole) {
+            print("[{browser.time.nowFormated()}] : " + strBuilder.toString() + " ({name})")
+        } else {
+            document.write(strBuilder.toString())
+        }
+        
+        strBuilder.clear()
+    }
+}
+```
+
+`index.lts` | The rendered file
+
+```ruby
+import Utils.Logging
+
+logger = new Logger("global", false)
+
+logger.append("This is a log message")
+logger.log()
+```
+
 ### namespace keyword
 
 The `namespace` keyword is used to declare certain functions, classes and interfaces as "belonging" to a namespace. That is, they are only accessible if this exact namespace is referenced through an `import` directive in the file wanting to use it. It can only be used once in a file. See [Namespaces]() and [from and import keywords]() for more information. It has the following format
@@ -505,10 +558,10 @@ The `namespace` keyword is used to declare certain functions, classes and interf
 
 *Example usage :*
 
-`perso_lib.lts` | File that contains functions in the `PersonalLib` namespace
+`text-utils.lts` | File that contains functions in the `Utils.Text` namespace
 
 ```ruby
-namespace PersonalLib
+namespace Utils.Text
 
 def capitalizeFirstLetter(inputString) {
     inputString[0] = inputString[0].toUpper()
@@ -516,10 +569,10 @@ def capitalizeFirstLetter(inputString) {
 }
 ```
 
-`index.lts` | File used as the website landing page
+`index.lts` | The rendered file
 
 ```ruby
-from "perso_lib.lts" import PersonalLib
+from "perso_lib.lts" import Utils.Text
 
 p {
     capitalizeFirstLetter("capitalization is important")
@@ -565,10 +618,10 @@ The `from` keyword is used in combination with an `import` statement to indicate
 
 *Example usage :*
 
-`perso_lib.lts` | File that contains functions in the `PersonalLib`  namespace
+`misc-utils.lts` | File that contains functions in the `Utils.Misc`  namespace
 
 ```ruby
-namespace PersonalLib
+namespace Utils.Misc
 
 def fibonacci(n) {
     current = 0
@@ -584,10 +637,10 @@ def fibonacci(n) {
 }
 ```
 
-`index.lts` | The homepage of the website
+`index.lts` | The rendered file
 
 ```ruby
-from "perso_lib.lts" import PersonalLib
+from "misc-utils.lts" import Utils.Misc
 
 for int i = 0; i < 10; i++; {
     p {        

--- a/docs/Internal/Lotus Syntax Module.md
+++ b/docs/Internal/Lotus Syntax Module.md
@@ -18,13 +18,9 @@ Last updated : *11th of May, 2019*
 
 This document describes the basic structure and syntax of Lotus source code. It defines, in details, the tokenizing, parsing, and translation of Lotus.
 
-
-
 ## Overview
 
 Lotus is an open-source language created to facilitate the work of web designers and web developpers. This document describes its syntax as well as the way it should be interpreted by a compiler to conform to the Lotus specification.
-
-
 
 ## Table of Contents
 
@@ -35,9 +31,11 @@ Lotus is an open-source language created to facilitate the work of web designers
 2. **[Tokenizing and Parsing Lotus](tokenizing-and-parsing-lotus)**
    
    - [x] [Definitions](definitions)
-   - [ ] [Token types](token-types)
+   - [x] [Token types](token-types)
    - [ ] [Tokens Railroad Diagrams](tokens-railroad-diagrams)
+   - [ ] [Tokenization Errors](tokenization-errors)
    - [ ] [Parser Railroad Diagrams](parser-railroad-diagrams)
+   - [ ] [Parsing Errors](parsing-errors)
    - [ ] [Parse Tree Model](parse-tree-model)
    - [ ] [Preprocessing the input stream](preprocessing-the-input-stream)
 
@@ -88,21 +86,15 @@ It also defines algorithms to convert text into a list of tokens, and then trans
 
 > Note: This is an example of an informative section
 
-
-
 **Examples :** Examples in this document are presented as a quote block and starts with the word "Example".
 
 > Example : This is an example of an example section
 
-
-
-**Short Code Segment :** Short code segments, such as token names, are presented in <code> tags.
+**Short Code Segment :** Short code segments, such as token names, are presented in `<code>` tags.
 
 `This is a short code segment`
 
-
-
-**Multi-line Code Segment :** Long/Multi-line code segments, such as informal code examples, are presented in <pre> tags.
+**Multi-line Code Segment :** Long/Multi-line code segments, such as informal code examples, are presented in `<pre>` tags.
 
 ```
 This is
@@ -110,122 +102,188 @@ A multiline
 Code segment
 ```
 
-
-
 **Informal section :** Informal sections are preceded by the words "*This section is informative*" written in *italics*.
 
-
-
-**Definition :** Words definitions are presented as h6 headers for the word(s) being defined, and the definition is presented in *italics* with a tab increment of 4 spaces.
-
-
+**Definition :** Words definitions are presented as h6 headers for the word(s) being defined, and the definition is presented in *italics*
 
 ## 2. Tokenizing and Parsing Lotus
 
 *This section is informal*
 
-
-
 Compiler and interpreter must use the parsing rules described in this specification to generate an *Abstract Syntax Tree* (AST) that can then be used to analyze, optimize or translate Lotus source code. 
-
-
 
 ### 2.1 Definitions
 
 This section defines terms used throughout this 
 
-
-
 ###### code point
 
-    A [Unicode code point](http://unicode.org/glossary/#code_point). A Unicode character with a value between 0 (hexadecimal) and 10FFFF (hexadecimal).
+*A [Unicode code point](http://unicode.org/glossary/#code_point). A Unicode character with a value between 0 (hexadecimal) and 10FFFF (hexadecimal).*
 
 ###### input stream
 
-    A Unicode stream (or list) of [code points](code-point).
+*A Unicode stream (or list) of [code points](code-point).*
 
 ###### consume the next code point
 
-    If the [input stream](input-stream) is treated as a stack, is analogous to poping a [code point](code-point) from the [input stream](input-stream) and returning the resulting [code point](code-point). If the [input stream](input-stream) is treated as an indexed list, is analogous to incrementing the list's index.
+*If the [input stream](input-stream) is treated as a stack, is analogous to poping a [code point](code-point) from the [input stream](input-stream) and returning the resulting [code point](code-point). If the [input stream](input-stream) is treated as an indexed list, is analogous to incrementing the list's index.*
 
 ###### next input code point
 
-    The first [code point](code-point) in the [input stream](input-stream) that has not been [consumed](consume-the-next-code-point) yet.
+*The first [code point](code-point) in the [input stream](input-stream) that has not been [consumed](consume-the-next-code-point) yet.*
 
 ###### current input code point
 
-    The last [code point](code-point) to have been [consumed](consume-the-next-code-point).
+*The last [code point](code-point) to have been [consumed](consume-the-next-code-point).*
 
 ###### reconsume the current code point
 
-    Push the [current input code point](current-input-code-point) on top of the [input stream](input-stream), so that next time you will need to [consume the next code point](consume-the-next-code-point), the [current input code point](current-input-code) will be [consumed](consume-the-next-code-point) instead.
+*Push the [current input code point](current-input-code-point) on top of the [input stream](input-stream), so that next time you will need to [consume the next code point](consume-the-next-code-point), the [current input code point](current-input-code) will be [consumed](consume-the-next-code-point) instead.*
 
 ###### EOF code point
 
-    A conceptual [code point](code-point) used to represent the end of the [input stream](input-stream). If the [input stream](input-stream) is empty, the [next code point](next-code-point) is always an [EOF code point](eof-code-point).
+*A conceptual [code point](code-point) used to represent the end of the [input stream](input-stream). If the [input stream](input-stream) is empty, the [next code point](next-code-point) is always an [EOF code point](eof-code-point).*
 
 ###### digit
 
-    A [code point](code-point) between U+0030 DIGIT ZERO (0) and U+0039 DIGIT NINE (9).
+*A [code point](code-point) between U+0030 DIGIT ZERO (0) and U+0039 DIGIT NINE (9).*
 
 ###### hex digit
 
-    A [digit](digit), or a [code point](code-point) between U+0041 LATIN CAPITAL LETTER A (A) and U+0046 LATIN CAPITAL LETTER F (F), or a [code point](https://www.w3.org/TR/css-syntax-3/#code-point "code point") between U+0061 LATIN SMALL LETTER A (a) and U+0066 LATIN SMALL LETTER F (f).
+*A [digit](digit), or a [code point](code-point) between U+0041 LATIN CAPITAL LETTER A (A) and U+0046 LATIN CAPITAL LETTER F (F), or a [code point](https://www.w3.org/TR/css-syntax-3/#code-point "code point") between U+0061 LATIN SMALL LETTER A (a) and U+0066 LATIN SMALL LETTER F (f).*
 
 ###### uppercase letter
 
-    A [code point](code-point) between U+0041 LATIN CAPITAL LETTER A (A) and U+005A LATIN CAPITAL LETTER Z (Z).
+*A [code point](code-point) between U+0041 LATIN CAPITAL LETTER A (A) and U+005A LATIN CAPITAL LETTER Z (Z).*
 
 ###### lowercase letter
 
-    A [code point](code-point) between U+0061 LATIN SMALL LETTER A (a) and U+007A LATIN SMALL LETTER Z (z).
+*A [code point](code-point) between U+0061 LATIN SMALL LETTER A (a) and U+007A LATIN SMALL LETTER Z (z).*
 
 ###### letter
 
-    An [uppercase letter](uppercase-letter) or a [lowercase letter](lowercase-letter).
+*An [uppercase letter](uppercase-letter) or a [lowercase letter](lowercase-letter).*
 
 ###### non-ASCII code point
 
-    A [code point](code-point) with a value equal or greater than U+0080 <control>.
+*A [code point](code-point) with a value equal or greater than U+0080 <control>.*
 
 ###### name code point
 
-    A  [letter](letter), a [digit](digit), a [non-ASCII code point](non-ascii-code-point), a U+002D HYPHEN MINUS (-), or a U+005F LOW LINE (_).
+*A  [letter](letter), a [digit](digit), a [non-ASCII code point](non-ascii-code-point), a U+002D HYPHEN MINUS (-), or a U+005F LOW LINE (_).*
 
 ###### newline
 
-    A [code point](code-point) with a value of U+000A LINE FEED (represented as the escape sequence '\n' in most programming language).
+*A [code point](code-point) with a value of U+000A LINE FEED (represented as the escape sequence '\n' in most programming language).*
 
 ###### whitespace
 
-    A [newline](newline), a U+D800 CHARACTER TABULATION, or a U+0020 SPACE.
+*A [newline](newline), a U+D800 CHARACTER TABULATION, or a U+0020 SPACE.*
 
 ###### maximum allowed code point
 
-    The [code point](code-point) with the value U+10FFF
+*The [code point](code-point) with the value U+10FFF.*
 
 ###### input token stream
 
-    The stream of tokens produced by the tokenizer.
+*The stream of tokens produced by the tokenizer.*
 
 ###### current input token
 
-    The last token from the [input token stream](input-token-stream) to have been [consumed](consume-a-token).
+*The last token from the [input token stream](input-token-stream) to have been [consumed](consume-a-token).*
 
 ###### next input token
 
-    The first token in the [input token stream](input-token-stream) that has not been [consumed](consume-a-token) yet.
+*The first token in the [input token stream](input-token-stream) that has not been [consumed](consume-a-token) yet.*
 
 ###### EOF token
 
-    A conceptual token used to represent the end of the [input token stream](input-token-stream). If the [input token stream](input-token-stream) is empty, the next token is always an [EOF token](eof-token).
+*A conceptual token used to represent the end of the [input token stream](input-token-stream). If the [input token stream](input-token-stream) is empty, the next token is always an [EOF token](eof-token).*
 
 ###### reconsume the current input token
 
-    Push the [current input token](current-input-token) on top of the [input token stream](input-token-stream), so that next time you will need to [consume the next token](consume-a-token), the [current input token](current-input-token) will be [consumed](consume-a-token) instead.
-
-
+*Push the [current input token](current-input-token) on top of the [input token stream](input-token-stream), so that next time you will need to [consume the next token](consume-a-token), the [current input token](current-input-token) will be [consumed](consume-a-token) instead.*
 
 ### 2.2 Token types
 
+Implementations should use the algorithms described in [section 4](tokenization), or act as they  use them (i.e. the resulting token stream should be identical, no matter the underlying implementation). The [tokenization](tokenization) phase should output a stream of zero or more of the following tokens.
 
+###### `<{-token>`
+
+*A token representing an opening curly brace (`{`). It doesn't hold any specific value.*
+
+###### `<}-token>`
+
+*A token representing a closing curly brace (`}`). It doesn't hold any specific value.*
+
+###### `<(-token>`
+
+*A token representing an opening/left parenthesis (`(`). It dosn't hold any specific value.*
+
+###### `<)-token>`
+
+*A token representing a closing/right parenthesis (`)`). It doesn't hold any specific value.*
+
+###### `<[-token>`
+
+*A token representing an opening/left square bracket (`[`). It doesn't hold any specific value.*
+
+###### `<]-token>`
+
+*A token representing a closing/right square bracket (`]`). It doesn't hold any specific value.*
+
+###### `<comma-token>`
+
+*A token representing a comma (`.`). It doesn't hold any specific value.*
+
+###### `<colon-token>`
+
+*A token representing a colon (`,`). It doesn't hold any specific value.*
+
+###### `<semicolon-token>`
+
+*A token representing a semicolon (`;`). It doesn't hold any specific value.*
+
+###### `<SLC-token>`
+
+*A token representing the start of a single line comment (i.e. U+0023 NUMBER SIGN (`#`)). It doesn't hold any specific value.*
+
+###### `<MLCD-token>`
+
+*A token representing a multi-line comment delimitor (i.e. U+0023 NUMBER SIGN U+0023 NUMBER SIGN U+0023 NUMBER SIGN (`###`)). It doesn't hold any specific value.*
+
+###### `<DCO-token>`
+
+*A token representing a opening delimiter of an embedded documentation (`=begin`). It doesn't hold any specific value.*
+
+###### `<DCC-token>`
+
+*A token representing a closing delimiter of an embedded documentation (`=end`). It doesn't hold any specific value.*
+
+###### `<logical-OR-token>`
+
+*A token representing a logical OR operator (i.e. U+007C VERTICAL LINE U+007C VERTICAL LINE (`||`)). It doesn't hold no specific value.*
+
+###### `<logical-AND-token>`
+
+*A token representing a logical AND operator (i.e. U+0026 AMPERSAND U+0026 AMPERSAND (`&&`)). It doesn't hold any specific value.*
+
+###### `<logical-XOR-token>`
+
+*A token representing a logical XOR operator (i.e. U+005E CIRCUMFLEX ACCENT (`^`)). It doesn't hold any specific value.*
+
+###### `<number-token>`
+
+*A token representing a number. It holds a value composed of one or more [code points](code-point), and a numeric value.*
+
+###### `<ident-token>`
+
+*A token representing an [identifier](identifier). It holds a value composed of one or more [code points](code-point).*
+
+###### `<assign-token>`
+
+*A token representing a single equals sign (`=`) [code point](code-point). It doesn't hold any specific value.*
+
+###### `<addition-token>`
+
+*A token representing a single plus sign (`+`) [code point](code-point). It doesn't hold any specific value.*

--- a/docs/Public/Classes/Boolean.md
+++ b/docs/Public/Classes/Boolean.md
@@ -1,0 +1,36 @@
+# Boolean class
+
+La classe pour utiliser les *booleans*, donc pour traiter les valeurs `true` et `false`.
+
+### Définition interne
+
+```ruby
+public class System.Object.Boolean
+```
+
+### Hérite de
+
+- Object
+
+## Méthodes et Constructeur
+
+### Constructeur
+
+| Nom    | Description                               | Accessibilité |
+| ------ | ----------------------------------------- | ------------- |
+| Bool() | Créer une nouvelle instance de `Boolean`. | public        |
+
+### Méthodes
+
+Aucune méthode n'existe pour cette classe.
+
+## Remarques
+
+Cette classe ne peut pas prendre d'arguments dans le constructeur.
+Le constructeur ainsi vaudra toujours `false`.
+
+## Historique & disponibilité
+
+Disponible depuis la version [À inserer].
+
+Aucun changement majeur depuis.

--- a/docs/Public/Classes/ClassTemplate.md
+++ b/docs/Public/Classes/ClassTemplate.md
@@ -5,7 +5,7 @@ Courte description de la classe.
 ### Définition interne
 
 ```ruby
-public class Namespace.Class_Name < Base_Class_Name
+public class Namespace.Class_Name extends Base_Class_Name
 ```
 
 ### Hérite de

--- a/docs/Public/Classes/ImageBox.md
+++ b/docs/Public/Classes/ImageBox.md
@@ -1,0 +1,81 @@
+# ImageBox class
+
+Courte description de la classe.
+
+### Définition interne
+
+```ruby
+public class System.ImageBox extends MediaBox
+```
+
+### Hérite de
+
+MediaBox
+
+### Héritée par
+
+Aucune class.
+
+## Méthodes & Constructeurs
+
+### Constructeurs
+
+| Nom                        | Description                                                                                                                                                                                       | Accessibilité |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| ImageBox()                 | Créer une nouvelle instance de `ImageBox`                                                                                                                                                         | public        |
+| ImageBox(string)           | Créer une nouvelle instance de `ImageBox` à partir du média désigné par l'argument.                                                                                                               | public        |
+| ImageBox(string, string)   | Créer une nouvellBoxe instance de `ImageBox` à partir de l'image désignée par le premier argument, et assigne le text alternatif à la valeur du deuxième argument.                                | public        |
+| ImageBox(string, int, int) | Créer une nouvelle instance de `ImageBox` à partir de l'image désignée par le premier argument, avec une longueur et une largeur définies, respectivement, par le deuxième et troisième argument. | public        |
+
+### Méthodes
+
+| Nom    | Description       | Type du résultat | Accessibilité |
+| ------ | ----------------- | ---------------- | ------------- |
+| show() | Affiche l'élément | void             | public        |
+| hide() | Cache l'élément   | void             | public        |
+
+## Membres
+
+| Nom     | Description                                                                                      | Type   | Accessibilité |
+| ------- | ------------------------------------------------------------------------------------------------ | ------ | ------------- |
+| alt     | Texte alternatif affiché si le fichier ne se charge pas ou si l'utilisateur à un handicap visuel | string | public        |
+| uri     | URI du média. Peut désigner un fichier local, à distance, ou une portion de document HTML        | URI    | public        |
+| visible | Indique si l'instance est visible                                                                | bool   | public        |
+
+## Exemple(s)
+
+```ruby
+# Un ou plusieurs exemples d'utilisation de cette classe
+```
+
+## Remarques
+
+Cette classe peut-être utilisée pour montrer des images. Les formats supportés sont ceux supportés par le tag `<img>` en HTML, c'est à dire : 
+
+-  JPEG (JPG)
+
+- PNG
+
+- TIFF
+
+- BMP
+
+- SVG
+
+- GIF
+
+
+
+Si vous avez besoin de manipuler les pixels de l'image, il est recommandé d'utiliser un objet `Canvas`.
+
+## Historique & disponibilité
+
+Disponible depuis la version a.b
+
+Aucun changement majeur depuis
+
+***OU***
+
+Changement à la version a.g :
+
+*Description du changement*

--- a/docs/Public/Classes/MediaBox.md
+++ b/docs/Public/Classes/MediaBox.md
@@ -1,11 +1,11 @@
-# ClassName class
+# MediaBox class
 
 Courte description de la classe.
 
 ### Définition interne
 
 ```ruby
-public class System.MediaBox < Box
+public class System.MediaBox extends Box
 ```
 
 ### Hérite de
@@ -22,16 +22,15 @@ Box
 
 - CodeBox
 
-
-
 ## Méthodes & Constructeurs
 
 ### Constructeurs
 
-| Nom              | Description                                                                        | Accessibilité |
-| ---------------- | ---------------------------------------------------------------------------------- | ------------- |
-| Mediabox()       | Créer une nouvelle instance de `MediaBox`                                          | public        |
-| MediaBox(string) | Créer une nouvelle instance de `MediaBox` à partir du média désigné par l'argument | public        |
+| Nom                      | Description                                                                                                                                                   | Accessibilité |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| Mediabox()               | Créer une nouvelle instance de `MediaBox`                                                                                                                     | public        |
+| MediaBox(string)         | Créer une nouvelle instance de `MediaBox` à partir du média désigné par l'argument                                                                            | public        |
+| MediaBox(string, string) | Créer une nouvelle instance de `MediaBox` à partir du média désigné par le première argument, et assigne le texte alternatif à la valeur du deuxième argument | public        |
 
 ### Méthodes
 
@@ -42,11 +41,11 @@ Box
 
 ## Membres
 
-| Nom     | Description                                                                                       | Type   | Accessibilité |
-| ------- | ------------------------------------------------------------------------------------------------- | ------ | ------------- |
-| alt     | Texte alternatif affiché si le fichier ne se charge pas ou si l'utilisateur à un handicap visuel  | string | public        |
-| uri     | URI du média. Peut désigner un fichier local, à distance, ou une portion de document HTML         | URI    | public        |
-| visible | Indique si l'instance est visible                                                                 | bool   | public        |
+| Nom     | Description                                                                                      | Type   | Accessibilité |
+| ------- | ------------------------------------------------------------------------------------------------ | ------ | ------------- |
+| alt     | Texte alternatif affiché si le fichier ne se charge pas ou si l'utilisateur à un handicap visuel | string | public        |
+| uri     | URI du média. Peut désigner un fichier local, à distance, ou une portion de document HTML        | URI    | public        |
+| visible | Indique si l'instance est visible                                                                | bool   | public        |
 
 ## Exemple(s)
 


### PR DESCRIPTION
A pull request to add the `new` keyword to the documentation and therefore language syntax. 

The `new` keyword is used in combination with a class's or interface's constructor to create a new instance of the class or interface

As this feature is not widely accepted, I am creating a new branch and submitting a pull request to make sure work can continue on the `master` branch without problems